### PR TITLE
Add configuration for subprojects and dependency cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,21 +3,48 @@ ThisBuild / organization := "de.bwhc"
 ThisBuild / scalaVersion := "2.13.8"
 ThisBuild / version      := "1.1-SNAPSHOT"
 
-
 //-----------------------------------------------------------------------------
-// DEPENDENCIES
+// PROJECTS
 //-----------------------------------------------------------------------------
 
-libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.8.1"
-)
+lazy val global = project
+  .in(file("."))
+  .settings(
+    settings,
+    publish / skip := true
+  )
+  .aggregate(
+    dtos,
+    generators
+  )
+
+lazy val dtos = project
+  .settings(
+    name := "mtb-dto-dtos",
+    settings,
+    libraryDependencies ++= Seq(
+      "com.typesafe.play" %% "play-json" % "2.8.1"
+    )
+  )
+
+
+lazy val generators = project
+  .settings(
+    name := "mtb-dto-generators",
+    settings,
+    libraryDependencies ++= Seq(
+      "de.ekut.tbi" %% "generators" % "0.1-SNAPSHOT"
+    )
+  )
+  .dependsOn(
+    dtos
+  )
 
 //-----------------------------------------------------------------------------
 // SETTINGS
 //-----------------------------------------------------------------------------
 
 lazy val settings = commonSettings
-
 
 lazy val compilerOptions = Seq(
   "-encoding", "utf8",

--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,7 @@ ThisBuild / version      := "1.1-SNAPSHOT"
 //-----------------------------------------------------------------------------
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.8.1",
-  "de.bwhc" %% "utils" % "1.0-SNAPSHOT"
+  "com.typesafe.play" %% "play-json" % "2.8.1"
 )
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This will build subprojects
* `dtos` as `mtb-dto-dtos`
* `generators` as `mtb-dto-generators`

Resulting JAR file names might need adjustment.

Dependency to `de.bwhc:utils` has been removed but dependency to `de.ekut.tbi:generators` has
been added to subproject `generators`.

Subproject `dtos` depends on `generators`.
